### PR TITLE
37-Angle-Wrap

### DIFF
--- a/include/ground_texture_sim/transform_math.h
+++ b/include/ground_texture_sim/transform_math.h
@@ -4,6 +4,7 @@
 #include <ignition/math/Quaternion.hh>
 #include <ignition/msgs/pose.pb.h>
 #include <ignition/msgs/quaternion.pb.h>
+#include <math.h>
 #include <tuple>
 
 /**
@@ -84,6 +85,14 @@ namespace ground_texture_sim {
 	 * @return std::tuple<double, double, double> A tuple containing the roll, pitch, and yaw.
 	 */
 	std::tuple<double, double, double> RPYFromQuaternionMsg(const ignition::msgs::Quaternion & quaternion);
+
+	/**
+	 * @brief Wraps an angle, in radians, to the range of [-Pi, PI].
+	 * 
+	 * @param angle The angle to wrap, in radians.
+	 * @return double The wrapped angle. Guaranteed to be between -Pi and Pi (inclusive).
+	 */
+	double wrapAngle(double angle);
 
 } // namespace ground_texture_sim
 

--- a/src/ground_texture_sim/transform_math.cpp
+++ b/src/ground_texture_sim/transform_math.cpp
@@ -29,4 +29,10 @@ namespace ground_texture_sim {
 		double yaw = quaternion_math.Yaw();
 		return std::make_tuple(roll, pitch, yaw);
 	}
+
+	double wrapAngle(double angle) {
+		// This uses a method provided in Ignition's math library:
+		// https://github.com/ignitionrobotics/ign-math/blob/db5edbfd7fbe519fae02601dfd2335c5b895d12c/include/ignition/math/Angle.hh
+		return atan2(sin(angle), cos(angle));
+	}
 } // namespace ground_texture_sim

--- a/test/test_transform_math.cpp
+++ b/test/test_transform_math.cpp
@@ -233,3 +233,25 @@ TEST(RPYFromQuaternionMsg, WrappedYaw) {
 	ASSERT_DOUBLE_EQ(pitch, 0.0);
 	ASSERT_DOUBLE_EQ(yaw, M_PI);
 }
+
+/// @test Test that angles already within the range aren't changed.
+TEST(WrapAngle, UnchangedValues) {
+	ASSERT_DOUBLE_EQ(0.0, ground_texture_sim::wrapAngle(0.0));
+	ASSERT_DOUBLE_EQ(M_PI_2, ground_texture_sim::wrapAngle(M_PI_2));
+	ASSERT_DOUBLE_EQ(-M_PI_2, ground_texture_sim::wrapAngle(-M_PI_2));
+}
+
+/// @test Test that angles outside of the range are wrapped correctly.
+TEST(WrapAngle, ChangedValues) {
+	ASSERT_DOUBLE_EQ(-M_PI_2, ground_texture_sim::wrapAngle(3.0 * M_PI_2));
+	ASSERT_DOUBLE_EQ(M_PI_2, ground_texture_sim::wrapAngle(-3.0 * M_PI_2));
+	ASSERT_DOUBLE_EQ(M_PI - 0.0002, ground_texture_sim::wrapAngle(-M_PI - 0.0002));
+}
+
+/// @test Test angles on the boundaries are wrapped correctly.
+TEST(WrapAngle, Boundary) {
+	ASSERT_DOUBLE_EQ(M_PI, ground_texture_sim::wrapAngle(3.0 * M_PI));
+	ASSERT_DOUBLE_EQ(-M_PI, ground_texture_sim::wrapAngle(-3.0 * M_PI));
+	ASSERT_DOUBLE_EQ(M_PI, ground_texture_sim::wrapAngle(M_PI));
+	ASSERT_DOUBLE_EQ(-M_PI, ground_texture_sim::wrapAngle(-M_PI));
+}


### PR DESCRIPTION
Adds angle wrapping before any interaction with Gazebo. This only wraps internally, it still presents the original values to whatever calls the trajectory following.

Closes #37 