### PR TITLE
36-Unit-Test-Change

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,12 +11,15 @@ jobs:
   unit_test:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Build Docker image
         uses: docker/build-push-action@v2
         with:
-          build-args: BUILD_TEST:ON
+          build-args: BUILD_TEST=ON
+          context: .
           push: false
           tags: ground-texture-sim:test
           target: build

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Build Docker image

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           build-args: BUILD_TEST=ON
           context: .
+          load: true
           push: false
           tags: ground-texture-sim:test
           target: build

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -8,6 +8,21 @@ on:
 
 jobs:
 
+  unit_test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Build Docker image
+        uses: docker/build-push-action@v2
+        with:
+          build-args: BUILD_TEST:ON
+          push: false
+          tags: ground-texture-sim:test
+          target: build
+      - name: Run Unit Tests
+        run: docker run ground-texture-sim:test ctest -VV
+
   build:
 
     runs-on: ubuntu-latest

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -20,25 +20,12 @@ jobs:
       - name: Build Docker image
         uses: docker/build-push-action@v2
         with:
-          build-args: BUILD_TEST=OFF
+          build-args: BUILD_TEST=ON
           context: .
           load: true
+          no-cache: true
           push: false
           tags: ground-texture-sim:test
           target: build
       - name: Run Unit Tests
         run: docker run ground-texture-sim:test ctest -VV
-
-  build:
-
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: 'recursive'
-    # The build stage has all of the code built, include gtest, so it is easy to run unit tests from there.
-    - name: Build the Docker image
-      run: docker build . --build-arg BUILD_TEST=ON --target build --file Dockerfile --tag ground-texture-sim:test
-    - name: Run tests
-      run: docker run ground-texture-sim:test ctest -VV

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
 
-  unit_test:
+  unit-test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Build Docker image
         uses: docker/build-push-action@v2
         with:
-          build-args: BUILD_TEST=ON
+          build-args: BUILD_TEST=OFF
           context: .
           load: true
           push: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,8 +44,7 @@ FROM base AS build
 COPY . /opt/ground-texture-sim
 WORKDIR /opt/ground-texture-sim/build
 ARG BUILD_TEST=OFF
-RUN pwd && \
-	cmake -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Release ..
+RUN pwd
 CMD [ "ctest", "-VV" ]
 
 # From the compiled version, copy over the applications needed to run.

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ FROM base AS build
 COPY . /opt/ground-texture-sim
 WORKDIR /opt/ground-texture-sim/build
 ARG BUILD_TEST=OFF
-RUN cmake -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Release -S /opt/ground-texture-sim -B /opt/ground-texture-sim/build && \
+RUN cmake -DBUILD_TESTING=${BUILD_TEST} -DCMAKE_BUILD_TYPE=Release -S /opt/ground-texture-sim -B /opt/ground-texture-sim/build && \
 	make -j && \
 	make install
 CMD [ "ctest", "-VV" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ FROM base AS build
 COPY . /opt/ground-texture-sim
 WORKDIR /opt/ground-texture-sim/build
 ARG BUILD_TEST=OFF
-RUN cmake -DBUILD_TESTING=${BUILD_TEST} -DCMAKE_BUILD_TYPE=Release .. && \
+RUN cmake -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Release .. && \
 	make -j && \
 	make install
 CMD [ "ctest", "-VV" ]
@@ -60,4 +60,4 @@ WORKDIR /home/user
 COPY config/ /home/user/config/
 COPY launch/ /home/user/launch/
 COPY world/ /home/user/world/
-CMD [ "ign", "launch", "launch/trajectory.ign" ]
+CMD [ "ign", "launch", "launch/generate_data.ign", "trajectory:=config/trajectory.txt" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,8 @@ FROM base AS build
 COPY . /opt/ground-texture-sim
 WORKDIR /opt/ground-texture-sim/build
 ARG BUILD_TEST=OFF
-RUN make -j && \
+RUN cmake -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Release -S /opt/ground-texture-sim -B /opt/ground-texture-sim/build && \
+	make -j && \
 	make install
 CMD [ "ctest", "-VV" ]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,8 @@ FROM base AS build
 COPY . /opt/ground-texture-sim
 WORKDIR /opt/ground-texture-sim/build
 ARG BUILD_TEST=OFF
-RUN cmake -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Release .. && make -j && make install
+RUN pwd && \
+	cmake -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Release ..
 CMD [ "ctest", "-VV" ]
 
 # From the compiled version, copy over the applications needed to run.

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,9 +44,7 @@ FROM base AS build
 COPY . /opt/ground-texture-sim
 WORKDIR /opt/ground-texture-sim/build
 ARG BUILD_TEST=OFF
-RUN cmake -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Release .. && \
-	make -j && \
-	make install
+RUN cmake -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Release .. && make -j && make install
 CMD [ "ctest", "-VV" ]
 
 # From the compiled version, copy over the applications needed to run.

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,8 @@ FROM base AS build
 COPY . /opt/ground-texture-sim
 WORKDIR /opt/ground-texture-sim/build
 ARG BUILD_TEST=OFF
-RUN pwd
+RUN make -j && \
+	make install
 CMD [ "ctest", "-VV" ]
 
 # From the compiled version, copy over the applications needed to run.


### PR DESCRIPTION
Modifies the unit test action to correctly pass build-args to the Docker builder. This way, it ensures that gtest dependencies are actually build every time, preventing accidental passing when not built.

Closes #36 