### PR TITLE
Fix BPY Unit Test Workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     # There are not dependencies at the moment, otherwise they would be installed here.
-    # - name: Install Dependencies
-    #   run: pip install -r requirements.dev.txt
+    - name: Install Dependencies
+      run: pip install -r requirements.dev.txt
     - name: Test with unittest
       run: python -m unittest -v

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     # There are not dependencies at the moment, otherwise they would be installed here.
-    - name: Install Dependencies
-      run: pip install -r requirements.dev.txt
+    # - name: Install Dependencies
+    #   run: pip install -r requirements.dev.txt
     - name: Test with unittest
       run: python -m unittest -v

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,5 +25,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     # There are not dependencies at the moment, otherwise they would be installed here.
+    - name: Install Dependencies
+      run: pip install -r requirements.dev.txt
     - name: Test with unittest
       run: python -m unittest -v

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apt update \
 # The development image will have development tools, like Git, installed.
 FROM base AS dev
 
-COPY requirements_dev.txt /tmp/
+COPY requirements.dev.txt /tmp/
 
 RUN apt update \
 	&& DEBIAN_FRONTEND=noninteractive \

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,8 @@ RUN apt update \
 # The development image will have development tools, like Git, installed.
 FROM base AS dev
 
+COPY requirements_dev.txt /tmp/
+
 RUN apt update \
 	&& DEBIAN_FRONTEND=noninteractive \
 	apt install -y \
@@ -25,10 +27,7 @@ RUN apt update \
 	python3-pip \
 	&& rm -rf /var/lib/apt/lists/* \
 	# Don't do a requirements file, since it is only needed for development.
-	&& pip install --upgrade \
-	autopep8 \
-	coverage \
-	pylint
+	&& pip install --upgrade -r /tmp/requirements.dev.txt
 
 CMD [ "blender" ]
 

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,0 +1,4 @@
+autopep8
+coverage
+fake-bpy-module-2.82
+pylint

--- a/test_data_generation.py
+++ b/test_data_generation.py
@@ -105,7 +105,8 @@ class TestReadConfig(unittest.TestCase):
 
         @return None
         """
-        input_string = '{\n"trajectory": "trajectory.txt",\n"output": "output/",\n"camera height": 1.0,\n"gpu": true\n}'
+        input_string = '{\n"trajectory": "trajectory.txt",\n"output": "output/"' \
+            ',\n"camera height": 1.0,\n"gpu": true\n}'
         expected_result = {
             'output': 'output/',
             'trajectory': 'trajectory.txt',


### PR DESCRIPTION
**Describe the changes**
This pull request fixes the broken unit tests caused by BPY not being found. As a workaround, it uses https://github.com/nutti/fake-bpy-module to emulate the API for bpy. This allows unit tests to run. It also consolidates the dependencies into a *requirements.dev.txt* file, so that the unit test workflow can install everything.

**Issue addressed**
Closes #53 